### PR TITLE
Link boost dependencies through interface.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,7 @@ if(Beast_BUILD_TESTS)
 endif(Beast_BUILD_TESTS)
 
 add_library(${PROJECT_NAME} INTERFACE)
+target_link_libraries(${PROJECT_NAME} INTERFACE Boost::system Boost::filesystem Boost::program_options Boost::context Boost::coroutine Boost::thread)
 
 ### Install ###
 set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,1 +1,3 @@
 include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")
+
+find_package(Boost CONFIG REQUIRED @BOOST_COMPONENTS@)


### PR DESCRIPTION
When linking Beast::Beast, it now automatically links all relevant Boost libraries/includes as well.